### PR TITLE
let use tmp/ as a cache for Sprockets

### DIFF
--- a/lib/jekyll/assets_plugin/environment.rb
+++ b/lib/jekyll/assets_plugin/environment.rb
@@ -27,6 +27,9 @@ module Jekyll
         self.js_compressor   = @site.assets_config.js_compressor
         self.css_compressor  = @site.assets_config.css_compressor
 
+        @sprockets_cache_path = File.join(@site.config['source'], 'tmp', 'cache')
+        self.cache           = Sprockets::Cache::FileStore.new(@sprockets_cache_path)
+
         # bind jekyll and Sprockets context together
         context_class.instance_variable_set :@site, @site
 


### PR DESCRIPTION
Sprockets has a built-in cache, lets leverage it!
its a huge performance gain if you have no changed assets and otherwise only the changed assets will be recompiled.

first time

```
$ time jekyll build
jekyll build  2,05s user 0,27s system 99% cpu 2,318 total
```

second time

```
$ time jekyll build
jekyll build  0,53s user 0,19s system 98% cpu 0,738 total
```
