### PR TITLE
Support turbolinks data attributes

### DIFF
--- a/lib/jekyll/assets_plugin/configuration.rb
+++ b/lib/jekyll/assets_plugin/configuration.rb
@@ -11,7 +11,8 @@ module Jekyll
         :compress     => { :css => nil, :js => nil },
         :cachebust    => :hard,
         :cache_assets => false,
-        :gzip         => %w{ text/css application/javascript }
+        :gzip         => %w{ text/css application/javascript },
+        :turbolinks   => false
       }.freeze
 
 
@@ -49,6 +50,10 @@ module Jekyll
 
       def cache_assets?
         !!@data.cache_assets
+      end
+
+      def turbolinks?
+        !!@data.turbolinks
       end
 
 

--- a/lib/jekyll/assets_plugin/renderer.rb
+++ b/lib/jekyll/assets_plugin/renderer.rb
@@ -2,8 +2,8 @@ module Jekyll
   module AssetsPlugin
     class Renderer
 
-      STYLESHEET = '<link rel="stylesheet" type="text/css" href="%s">'
-      JAVASCRIPT = '<script type="text/javascript" src="%s"></script>'
+      STYLESHEET = '<link rel="stylesheet" type="text/css" href="%s" data-turbolinks-track>'
+      JAVASCRIPT = '<script type="text/javascript" src="%s" data-turbolinks-track></script>'
 
 
       def initialize context, logical_path
@@ -25,14 +25,22 @@ module Jekyll
       def render_javascript
         @path << ".js" if File.extname(@path).empty?
 
-        JAVASCRIPT % render_asset_path
+        ret = JAVASCRIPT % render_asset_path
+        if !@site.assets_config.turbolinks?
+          ret = ret.gsub(/data-turbolinks-track/, '')
+        end
+        ret
       end
 
 
       def render_stylesheet
         @path << ".css" if File.extname(@path).empty?
 
-        STYLESHEET % render_asset_path
+        ret = STYLESHEET % render_asset_path
+        if !@site.assets_config.turbolinks?
+          ret = ret.gsub(/data-turbolinks-track/, '')
+        end
+        ret
       end
 
     end


### PR DESCRIPTION
turbolinks requires to add `data-turbolinks-track` to detect assets have been changed. (FYI:  https://github.com/rails/turbolinks#asset-change-detection ) I made a change that adds data attributes into script and  stylesheet link tag.
