### PR TITLE
Fix bug where assets could not be found by relative path

### DIFF
--- a/lib/jekyll/assets_plugin/patches/context_patch.rb
+++ b/lib/jekyll/assets_plugin/patches/context_patch.rb
@@ -18,8 +18,9 @@ module Jekyll
 
 
         def asset_path pathname, *args
-          jekyll_assets << resolve(pathname.to_s[/^[^#?]+/]).to_s
-          site.asset_path pathname, *args
+          asset = resolve(pathname.to_s[/^[^#?]+/]).to_s
+          jekyll_assets << asset
+          (site.asset_path asset, *args) + (pathname.to_s[/[#?].+/] || '')
         rescue Sprockets::FileNotFound
           raise Environment::AssetNotFound, pathname
         end

--- a/spec/fixtures/_assets/lib/relative.css.scss
+++ b/spec/fixtures/_assets/lib/relative.css.scss
@@ -1,0 +1,12 @@
+/* copy of vapor css framework to test relative asset inclusion*/
+
+@font-face {
+  font-family: 'Vapor';
+  src: url(font_path('../fonts/vapor.eot'));
+  src: url(font_path('../fonts/vapor.eot?#iefix')) format("embedded-opentype"),
+       url(font_path('../fonts/vapor.woff')) format("woff"),
+       url(font_path('../fonts/vapor.ttf')) format("truetype"),
+       url(font_path('../fonts/vapor.svg#iefix')) format("svg");
+  font-weight: normal;
+  font-style: normal;
+}

--- a/spec/lib/jekyll/assets_plugin/environment_spec.rb
+++ b/spec/lib/jekyll/assets_plugin/environment_spec.rb
@@ -9,6 +9,13 @@ module Jekyll::AssetsPlugin
         css.should =~ %r{fonts/vapor-[a-f0-9]{32}\.eot\?#iefix}
         css.should =~ %r{fonts/vapor-[a-f0-9]{32}\.svg#iefix}
       end
+
+      it "should properly handle relative paths" do
+        css = @site.assets["lib/relative.css"].to_s
+        css.should =~ %r{/assets/fonts/vapor-[a-f0-9]{32}\.eot\?#iefix}
+        css.should =~ %r{/assets/fonts/vapor-[a-f0-9]{32}\.svg#iefix}
+        puts css
+      end
     end
   end
 end


### PR DESCRIPTION
I was unable to request paths relative to the currently processed file.  This fixed the issue and adds a spec to capture the regression.
