### PR TITLE
Add the ability to precompile assets to the source directory.

### DIFF
--- a/lib/jekyll/assets_plugin/patches/asset_patch.rb
+++ b/lib/jekyll/assets_plugin/patches/asset_patch.rb
@@ -66,12 +66,20 @@ module Jekyll
             write_to dest_path
             write_to "#{dest_path}.gz" if gzip?
 
+            write_to destination(site.source) if precompile?
+            write_to "#{destination(site.source)}.gz" if gzip? && precompile?
+
             true
           end
 
 
           def gzip?
             site.assets_config.gzip.include? content_type
+          end
+
+
+          def precompile?
+            site.assets_config.precompile
           end
 
         end


### PR DESCRIPTION
This enables using safe mode and the default jekyll setup on github pages,
as long `jekyll build` is run once in unsafe mode after files in
the _assets directory are modified.

I'm doing this because `jekyll-assets` is the only plugin I'm using
and this gives me the flexibility to make changes to `_posts` using
the github interface or something.
