### PR TITLE
Inject the autoprefixer-rails CSS post-processor if present in the load path

### DIFF
--- a/lib/jekyll/assets_plugin/environment.rb
+++ b/lib/jekyll/assets_plugin/environment.rb
@@ -35,6 +35,13 @@ module Jekyll
           self.cache = Sprockets::Cache::FileStore.new cache_path
         end
 
+        # load css autoprefix post-processor
+        begin
+          require 'autoprefixer-rails'
+          AutoprefixerRails.install(self)
+        rescue LoadError
+        end
+
         # reset cache if config changed
         self.version = site.assets_config.marshal_dump
 


### PR DESCRIPTION
Per my recent issue, #67, this is the patch I'm using to add support for the autoprefixer-rails gem in my local fork. It's a really handy gem which handles CSS vendor prefixes automatically, basically replacing most of my use cases for Compass and Bourbon and the like.

My first stab here loads the gem in `Environment#initialize` if present in the load path. I'm not sure this is the best approach for everyone. Personally, in the day and age of Bundler, the presence of the gem in the load path is enough of an opt-in for me. But that may be too liberal for others.

So I'm open to suggestions on better modularity here. The trick is having access to the right scope for the Sprockets environment object, balanced with some better opt-in from the user to include the autoprefixer.
