### PR TITLE
Fix bug where #asset_path could raise TypeError

### DIFF
--- a/lib/jekyll/assets_plugin/patches/context_patch.rb
+++ b/lib/jekyll/assets_plugin/patches/context_patch.rb
@@ -18,7 +18,7 @@ module Jekyll
 
 
         def asset_path pathname, *args
-          asset = resolve(pathname.to_s[/^[^#?]+/]).to_s
+          asset = resolve(pathname.to_s[/^[^#?]+/] || '').to_s
           jekyll_assets << asset
           (site.asset_path asset, *args) + (pathname.to_s[/[#?].+/] || '')
         rescue Sprockets::FileNotFound

--- a/spec/fixtures/_assets/should_fail_blank.css.erb
+++ b/spec/fixtures/_assets/should_fail_blank.css.erb
@@ -1,0 +1,1 @@
+body { background-image: url(<%= image_path '' %>) }

--- a/spec/lib/jekyll/assets_plugin/patches/site_patch_spec.rb
+++ b/spec/lib/jekyll/assets_plugin/patches/site_patch_spec.rb
@@ -34,6 +34,14 @@ module Jekyll::AssetsPlugin
             end
           end
 
+          context "when passed a blank path" do
+            it "should raise a NotFound error" do
+              Proc.new do
+                site.assets["should_fail_blank.css"]
+              end.should raise_error(Environment::AssetNotFound)
+            end
+          end
+
           context "when requested file found" do
             it "should have proper asset path" do
               noise_img_re = %r{url\(/assets/noise-[a-f0-9]{32}\.png\)}


### PR DESCRIPTION
It raised `#<TypeError: no implicit conversion of nil into String>` from `Pathname#new` when passed a blank `pathname`.  `AssetNotFound` error was expected in this case too.

Such a request is actually made by [bootstrap-sass](https://github.com/twbs/bootstrap-sass/blob/master/vendor/assets/stylesheets/bootstrap/_variables.scss) via `twbs-font-path()` function.

``` sass
// a flag to toggle asset pipeline / compass integration
// defaults to true if twbs-font-path function is present (no function => twbs-font-path('') parsed as string == right side)
// in Sass 3.3 this can be improved with: function-exists(twbs-font-path)
$bootstrap-sass-asset-helper: (twbs-font-path("") != unquote('twbs-font-path("")')) !default;
```
