### PR TITLE
Fix #asset_path errors against blank path requests

### DIFF
--- a/lib/jekyll/assets_plugin/patches/context_patch.rb
+++ b/lib/jekyll/assets_plugin/patches/context_patch.rb
@@ -18,6 +18,7 @@ module Jekyll
 
 
         def asset_path pathname, *args
+          return "" if pathname.to_s.strip.empty?
           asset = resolve(pathname.to_s[/^[^#?]+/]).to_s
           jekyll_assets << asset
           (site.asset_path asset, *args) + (pathname.to_s[/[#?].+/] || '')

--- a/spec/fixtures/_assets/should_be_blank.css.erb
+++ b/spec/fixtures/_assets/should_be_blank.css.erb
@@ -1,0 +1,1 @@
+body { background-image: url(<%= image_path '' %>) }

--- a/spec/lib/jekyll/assets_plugin/patches/site_patch_spec.rb
+++ b/spec/lib/jekyll/assets_plugin/patches/site_patch_spec.rb
@@ -40,6 +40,13 @@ module Jekyll::AssetsPlugin
               site.assets["app.css"].to_s.should match(noise_img_re)
             end
           end
+
+          context "when passed a blank path" do
+            it "should be blank" do
+              css = site.assets["should_be_blank.css"].to_s
+              css.should =~ /url\(\)/
+            end
+          end
         end
       end
 


### PR DESCRIPTION
It raised `#<TypeError: no implicit conversion of nil into String>` from `Pathname#new` when passed a blank `pathname`.  It should return an empty string without error in this case, following the behavior of [`ActionView::Helpers::AssetUrlHelper#asset_path`](https://github.com/rails/rails/blob/master/actionview/lib/action_view/helpers/asset_url_helper.rb#L120).

This is a revised pull request of #71.
