### PR TITLE
Added built-in support for Bitters (needs review)

### DIFF
--- a/lib/jekyll-assets/bitters.rb
+++ b/lib/jekyll-assets/bitters.rb
@@ -1,0 +1,4 @@
+require "sprockets"
+
+bitters_root = Gem::Specification.find_by_name("bitters").gem_dir
+Sprockets.append_path File.join(bitters_root, "app", "assets", "stylesheets")

--- a/spec/fixtures/_assets/vendor/with_bitters.css.sass
+++ b/spec/fixtures/_assets/vendor/with_bitters.css.sass
@@ -1,0 +1,5 @@
+@import "bourbon"
+@import "base/base"
+
+body
+  font-size: $base-font-size

--- a/spec/lib/jekyll-assets/bitters_spec.rb
+++ b/spec/lib/jekyll-assets/bitters_spec.rb
@@ -1,0 +1,8 @@
+require "spec_helper"
+require "jekyll-assets/bitters"
+
+RSpec.describe "Bitters integration" do
+  it "globally appends bitters paths into Sprockets environment" do
+    expect(@site.assets["vendor/with_bitters.css"].to_s).to match(/font-size/)
+  end
+end


### PR DESCRIPTION
This is my first attempt to create a built-in support for Bitters (extension from Bourbon and Neat). I don't know how to test this locally by installing the gem from a local repository. So please review this and test it, as I'm not sure how that locally testing works.
Hope this is a valid and useful contribution to your plugin. Keep up the great work that you do.
