### PR TITLE
Fix Liquid tag generates no space between attributes

### DIFF
--- a/lib/jekyll/assets_plugin/renderer.rb
+++ b/lib/jekyll/assets_plugin/renderer.rb
@@ -12,6 +12,7 @@ module Jekyll
         @path   = logical_path.strip
 
         @path, _, @attrs = @path.partition(" ") if @path[" "]
+        @attrs.prepend(" ") if @attrs
       end
 
       def render_asset

--- a/spec/lib/jekyll/assets_plugin/tag_spec.rb
+++ b/spec/lib/jekyll/assets_plugin/tag_spec.rb
@@ -17,14 +17,20 @@ RSpec.describe Jekyll::AssetsPlugin::Tag do
   end
 
   context "{% image <file> %}" do
-    def tag_re(name)
+    def tag_re(name, attrs = "")
       file = "/assets/#{name}-[a-f0-9]{32}\.png"
-      Regexp.new "^#{render_tag :IMAGE, file}$"
+      attrs.prepend(" ") unless attrs.empty?
+      Regexp.new "^#{render_tag :IMAGE, file, attrs}$"
     end
 
     context "when <file> exists" do
       subject { render("{% image noise.png %}") }
       it { is_expected.to match tag_re("noise") }
+    end
+
+    context "when <file> has an attribute" do
+      subject { render("{% image noise.png alt=\"Foobar\" %}") }
+      it { is_expected.to match tag_re("noise", "alt=\"Foobar\"") }
     end
 
     context "when <file> does not exists" do
@@ -34,14 +40,20 @@ RSpec.describe Jekyll::AssetsPlugin::Tag do
   end
 
   context "{% stylesheet <file> %}" do
-    def tag_re(name)
+    def tag_re(name, attrs = "")
       file = "/assets/#{name}-[a-f0-9]{32}\.css"
-      Regexp.new "^#{render_tag :STYLESHEET, file}$"
+      attrs.prepend(" ") unless attrs.empty?
+      Regexp.new "^#{render_tag :STYLESHEET, file, attrs}$"
     end
 
     context "when <file> exists" do
       subject { render("{% stylesheet app.css %}") }
       it { is_expected.to match tag_re("app") }
+    end
+
+    context "when <file> has an attribute" do
+      subject { render("{% stylesheet app.css type=\"text/css\" %}") }
+      it { is_expected.to match tag_re("app", "type=\"text/css\"") }
     end
 
     context "when <file> name has multiple dots" do
@@ -61,14 +73,20 @@ RSpec.describe Jekyll::AssetsPlugin::Tag do
   end
 
   context "{% javascript <file> %}" do
-    def tag_re(name)
+    def tag_re(name, attrs = "")
       file = "/assets/#{name}-[a-f0-9]{32}\.js"
-      Regexp.new "^#{render_tag :JAVASCRIPT, file}$"
+      attrs.prepend(" ") unless attrs.empty?
+      Regexp.new "^#{render_tag :JAVASCRIPT, file, attrs}$"
     end
 
     context "when <file> exists" do
       subject { render("{% javascript app.js %}") }
       it { is_expected.to match tag_re("app") }
+    end
+
+    context "when <file> has an attribute" do
+      subject { render("{% javascript app.js type=\"text/javascript\" %}") }
+      it { is_expected.to match tag_re("app", "type=\"text/javascript\"") }
     end
 
     context "when <file> name has multiple dots" do


### PR DESCRIPTION
When using Liquid tags with attributes there is no white space being generated between attributes causing errors when validating HTML. For example:

```
{% stylesheet app type="text/css" %}
```

Generates

```
<link rel="stylesheet" src="/assets/app.css"type="text/css">
```

To fix a space is prepend to each attribute so a Liquid tag with attributes now gets generated correctly like:

```
<link rel="stylesheet" src="/assets/app.css" type="text/css">
```

Signed-off-by: Tom Diggle tom@tomdiggle.com
