### PR TITLE
Path has changed in font-awesome-sass version 4.2.0.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem "compass"
 gem "bourbon"
 gem "neat"
 gem "bootstrap-sass"
-gem "font-awesome-sass"
+gem "font-awesome-sass", "~> 4.2.0"
 
 # compass fails with SASS than 3.3+
 # https://github.com/chriseppstein/compass/issues/1513

--- a/lib/jekyll-assets/font-awesome.rb
+++ b/lib/jekyll-assets/font-awesome.rb
@@ -2,5 +2,5 @@ require "sprockets"
 
 fa = Gem::Specification.find_by_name("font-awesome-sass").gem_dir
 %w[fonts stylesheets].each do |asset|
-  Sprockets.append_path File.join(fa, "vendor", "assets", asset)
+  Sprockets.append_path File.join(fa, "assets", asset)
 end


### PR DESCRIPTION
It is no longer "vendor/assets", just "assets".

This PR fixes that and enables font-awesome 4.2.0 to work properly again.
