### PR TITLE
Mention Sass precision Bootstrap fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,10 @@ Require `jekyll-assets/bootstrap` to enable, e.g.:
 
 ``` ruby
 require "jekyll-assets"
+
+# bootstrap requires minimum precision of 10, see https://github.com/twbs/bootstrap-sass/issues/409
+::Sass::Script::Number.precision = [10, ::Sass::Script::Number.precision].max
+
 require "jekyll-assets/bootstrap"
 ```
 


### PR DESCRIPTION
If your buttons line-height is 1.42857 instead of 1.428571429, this is because the precision is set to 5 instead of 10.

Digging into bootstrap-sass code, it looks like it [should be automatically fixed](https://github.com/twbs/bootstrap-sass/blob/master/lib/bootstrap-sass.rb#L56) but did not work in my configuration at least.
