### PR TITLE
remove unnecessary strip

### DIFF
--- a/lib/jekyll/assets_plugin/renderer.rb
+++ b/lib/jekyll/assets_plugin/renderer.rb
@@ -78,7 +78,7 @@ module Jekyll
           width, height = FastImage.size(site.assets[path].pathname)
         end
 
-        @attrs = %(#{@attrs} width="#{width}" height="#{height}").strip
+        @attrs = %(#{@attrs} width="#{width}" height="#{height}")
       end
 
       def autosize?


### PR DESCRIPTION
This pull request removes the `strip` around setting the autosize attributes.

This fixes the case when `attrs` is empty; the resulting html is

``` html
<img src="noise-123123123123.png"width="100" height="100">
```

which breaks the `img` tag on some browsers (I'm looking at chrome 39 on mac)
