### PR TITLE
Improve documentation of assets array in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ body {
 
 ## List
 
-We provide all *your* assets as a hash of Liquid Drops so you can get basic info that we wish you to have access to without having to prepare the class.
+We provide all *your* assets as a hash of Liquid Drops so you can get basic info that we wish you to have access to without having to prepare the class. **Note:** The keys in the `assets` array are the names of the original files, e.g., use `*.scss` instead of `*.css`.
 
 ```liquid
 {{ assets["bundle.css"].content_type }} => "text/css"

--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ The current list of available accessors:
 | `filename` | The full path to the assets actual file |
 | `width` | The asset width ***(if available)*** |
 | `digest_path` | The prefixed path |
+| `integrity` | The SRI hash (currently sha256) |
 
 ### Looping
 


### PR DESCRIPTION
## Description
While setting up jekyll-assets in conjunction with both Subresource Integrity (SRI) and a Content Security Policy (CSP), I learned of two details of the `assets` array that I would like to see mentioned in the `README.md`.

First, the array provides an `integrity` property for every asset, containing a sha256 hash of the resource.  This is very useful for generating CSP policies or asynchronously loading style sheets with SRI.

Second, I noticed that I could not use the file name of a generated resource (e.g. `style.css`) as a key for that array, but rather had to use the name of the original file (e.g. `style.scss`).