### PR TITLE
Don't emit CORS attributes for inline assets

### DIFF
--- a/lib/jekyll/assets/plugins/html/defaults/css.rb
+++ b/lib/jekyll/assets/plugins/html/defaults/css.rb
@@ -31,7 +31,7 @@ module Jekyll
         # --
         def integrity?
           config[:integrity] && !@asset.is_a?(Url) &&
-            !@args.key?(:integrity)
+            !@args.key?(:integrity) && !@args[:inline]
         end
       end
     end

--- a/lib/jekyll/assets/plugins/html/defaults/js.rb
+++ b/lib/jekyll/assets/plugins/html/defaults/js.rb
@@ -31,7 +31,7 @@ module Jekyll
         # --
         def integrity?
           config[:integrity] && !@asset.is_a?(Url) &&
-            !@args.key?(:integrity)
+            !@args.key?(:integrity) && !@args[:inline]
         end
       end
     end


### PR DESCRIPTION
The CORS-related `integrity` and `crossorigin` attributes are only
relevant for external resources and are explicitly not required on
inline scripts and styles. With this change, the attributes are no
longer emitted for assets rendered inline unless they are set
explicitly.