### PR TITLE
Proxy: digest based on the file too, fix #472

### DIFF
--- a/lib/jekyll/assets/proxy.rb
+++ b/lib/jekyll/assets/proxy.rb
@@ -82,8 +82,8 @@ module Jekyll
       end
 
       def self.digest(args)
-        Digest::SHA256.hexdigest(args.instance_variable_get(
-          :@raw))[0, 6]
+        Digest::SHA256.hexdigest("#{args[:argv1]}#{args.instance_variable_get(
+          :@raw)}")[0, 6]
       end
 
       # --

--- a/spec/tests/lib/jekyll/assets/proxy_spec.rb
+++ b/spec/tests/lib/jekyll/assets/proxy_spec.rb
@@ -80,4 +80,24 @@ describe Jekyll::Assets::Proxy do
         .new(asset.filename).binread))
     end
   end
+
+  context "with same tag but different files" do
+    let(:args2) do
+      args2 = Liquid::Tag::Parser.new("img.png @test:2x")
+      args2.args[:argv1] = "img2.png"
+      args2
+    end
+
+    it "returns different files" do
+      out = subject.proxy(asset, {
+        args: args, ctx: Thief.ctx
+      })
+
+      out2 = subject.proxy(asset, {
+        args: args2, ctx: Thief.ctx
+      })
+
+      expect(out).not_to eq(out2)
+    end
+  end
 end


### PR DESCRIPTION
- [x] I have added or updated the specs.
- [x] I have verified that the specs pass on my computer.
- [x] I have not attempted to bump, or alter versions.
- [ ] This is a documentation change.
- [x] This is a source change.

## Description

Hi @envygeeks 👋 ,

Let me tell you a story: Long time ago, I stopped writing code professional for reasons I can explain you when we are having beer some time. Since then, I am only writing for fun or when I try to help others. Never forget your real friends, they say, right?

So destiny brought me to bringing a proper asset management to a jekyll install and your gem looked very promising. Since a lot of this stuff in this jekyll install is autogenerated, I quickly found out, as soon as I try to resize images on the fly with the `magick` flag, I always got the last image of all images. Looked weird but I was happy seeing other fine people like @gasparesganga and @nielsenramon having the same problem in #472 . It was clear that this was some tiny duplication error somewhere in the guts of the gem. Sadly after my comment, you just locked the conversation, which made me think what does that suppose to mean. Will he fix? Maybe not? Is he busy? If not, when will he have time? I couldn't really read the message you send with this and I was lost. So I went to try to fix it by myself because if there is one thing you can learn from watching Friends is that unagi is not only a sushi but only be achieving true unagi, you can be prepared any danger that may befall you.

I am not familiar with your code base, so it might be not the best way to do it but I tried my best. At least I could keep the conversation up without spamming your repo and providing a workaround until you fix it properly.

Thank you very much, 💖 💖 💖 💖 💖 💖 💖 
ben