### PR TITLE
Update tag.rb

### DIFF
--- a/lib/jekyll/assets/tag.rb
+++ b/lib/jekyll/assets/tag.rb
@@ -194,7 +194,7 @@ module Jekyll
         env = ctx.registers[:site].sprockets
 
         env.logger.error e.message
-        env.logger.efile args[:argv1]
+        env.logger.err_file args[:argv1]
         raise e.class, "JS Error"
       end
 


### PR DESCRIPTION
That should be err_file too! As in https://github.com/envygeeks/jekyll-assets/commit/b4fa50349196c3412a27e910575ffffb96147ef1

- [ ] I have added or updated the specs.
- [ ] I have verified that the specs pass on my computer.
- [ ] I have not attempted to bump, or alter versions.
- [ ] This is a documentation change.
- [x] This is a source change.

## Description

Got following in my console:
```
           Assets:  (en: "Choose file...") isn't a valid CSS value.
  Liquid Exception: undefined method `efile' for Jekyll::Assets::Logger:Class Did you mean? err_file in /_layouts/default.html
jekyll 3.7.2 | Error:  undefined method `efile' for Jekyll::Assets::Logger:Class
Did you mean?  err_file

```

So I found that you already fixed this for CSS but not for JS.