### PR TITLE
Pass configured options to Uglifier

### DIFF
--- a/lib/jekyll/assets/compressors/uglify.rb
+++ b/lib/jekyll/assets/compressors/uglify.rb
@@ -16,8 +16,14 @@ module Jekyll
         end
       end
 
-      # rubocop:disable Metrics/LineLength
-      Sprockets.register_compressor "application/javascript", :assets_uglify, Uglify
+      Hook.register :env, :before_init, priority: 1 do |e|
+        uglifier_config = e.asset_config[:compressors][:uglifier].symbolize_keys
+
+        Sprockets.register_compressor "application/javascript",
+          :assets_uglify,
+          Uglify.new(uglifier_config)
+      end
+
       Hook.register :env, :after_init, priority: 3 do |e|
         e.js_compressor = nil
         next unless e.asset_config[:compression]


### PR DESCRIPTION
- [ ] I have added or updated the specs.
- [x] I have verified that the specs pass on my computer.
- [x] I have not attempted to bump, or alter versions.
- [ ] This is a documentation change.
- [x] This is a source change.

## Description

The [defaults in `Jekyll::Assets::Config`][1] include some configuration for Uglifier - e.g. enabling Harmony mode so you get ES6 support.

However, we don't actually do anything with this configuration as of 218f5ee98ad2f39860a58111336f5049ee23f341 (see `Jekyll::Assets::Env#enable_compression!` which is removed). This leads to issues like #511.

This starts passing that configuration into `Uglify`, our `Sprockets::UglifierCompressor` subclass, in
`lib/jekyll/assets/compressors/uglify.rb`. The [in-code documentation for Sprockets][2] notes that you can supply an instantiated, configured instance rather than a class and it'll be used.

Fixes #511.

[1]: https://github.com/envygeeks/jekyll-assets/blob/master/lib/jekyll/assets/config.rb#L24
[2]: https://github.com/rails/sprockets/blob/master/lib/sprockets/uglifier_compressor.rb#L16