### PR TITLE
Loop over raw_precompile items instead of taking the first one by default

### DIFF
--- a/lib/jekyll/assets/utils.rb
+++ b/lib/jekyll/assets/utils.rb
@@ -71,17 +71,17 @@ module Jekyll
               }
             end
           else
-            src = glob_paths(v).first
+            glob_paths(v).each do |path|
+              next unless path
+              dst = in_dest_dir(strip_paths(path))
+              dst.parent.mkdir_p
 
-            next unless src
-            dst = in_dest_dir(strip_paths(src))
-            dst.parent.mkdir_p
-
-            a << {
-              src: src,
-              full_dst: dst,
-              dst: dst,
-            }
+              a << {
+                src: path,
+                full_dst: dst,
+                dst: dst,
+              }
+            end
           end
         end
       end


### PR DESCRIPTION
- [ ] I have added or updated the specs.
- [x] I have verified that the specs pass on my computer.
- [x] I have not attempted to bump, or alter versions.
- [ ] This is a documentation change.
- [x] This is a source change.

## Description

When trying to set a regexp in raw_precompile only the first matching item is copied to assets folder.

## Example

`_config.yml` :
```yaml
assets:
  precompile: []
  raw_precompile:
    - "*featured.jpg"
```

**_assets** directory structure (before server run):

>  - _assets/
>    - img/
>      - image1-featured.jpg
>      - image2-featured.jpg
>      - image3-featured.jpg

Generated **assets** directory (after server run):

> - assets/
>   - image1-featured.jpg

*image2-featured.jpg* and *image3-featured.jpg* are missing.

## Solution

Loop over matching pattern and copy each one to the destination.