### PR TITLE
Fix exception name error in image optim code, extend documentation

### DIFF
--- a/lib/jekyll/assets/plugins/proxy/optim.rb
+++ b/lib/jekyll/assets/plugins/proxy/optim.rb
@@ -26,7 +26,7 @@ module Jekyll
         def process
           optimc = @env.asset_config[:plugins][:img][:optim]
           preset = @args[:optim] == true ? :jekyll : @args[:optim].to_sym
-          raise UnknownPreset, preset if preset != :jekyll && !optimc.key?(preset)
+          raise UnknownPresetError, preset if preset != :jekyll && !optimc.key?(preset)
           optim = ::ImageOptim.new(optimc[preset] || {})
           optim.optimize_image!(@file)
           @file


### PR DESCRIPTION
- [ ] I have added or updated the specs/tests.
- [ ] I have verified that the specs/tests pass on my computer.
- [x] I have not attempted to bump, or alter versions.
- [ ] This is a documentation change.
- [x] This is a source change.

## Description

Hi,

I encounterd errors and difficulties while trying to use the image optimisation plugin, so there is my attempt to fix both.

The code raise an undefined exception if the preset is not found in the configuration so i remplaced it with the exception defined 
`  Liquid Exception: uninitialized constant Jekyll::Assets::Plugins::ImageOptim::UnknownPreset Did you mean? Jekyll::Assets::Plugins::ImageOptim::UnknownPresetError in /_layouts/default.html
`

Also the documentation was very misleading for me so i tried to extend it by adding some examples of configuration and usage.

Regards,
Benoit