### PR TITLE
Use correct gem for bootstrap 3.x inclusion. Boostrap-sass is a empty…

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,11 +446,15 @@ assets:
 
 ### Bootstrap
 
+***Gemfile***
 ```ruby
-gem "boostrap-sass" # 3.x
+gem "bootstrap-sass" # 3.x or:
 gem "bootstrap"     # 4.x
 ```
 
+***SCCS Inclusion***
+
+ * Using @import:
 ```scss
 @import 'bootstrap'
 html {
@@ -458,6 +462,7 @@ html {
 }
 ```
 
+ * Using =require:
 ```scss
 //=require _bootstrap.css
 //=require bootstrap/_reboot.css

--- a/lib/jekyll/assets/plugins/bootstrap.rb
+++ b/lib/jekyll/assets/plugins/bootstrap.rb
@@ -4,6 +4,6 @@
 # Encoding: utf-8
 
 Jekyll::Assets::Utils.activate "bootstrap"
-Jekyll::Assets::Utils.activate "boostrap-sass" do
+Jekyll::Assets::Utils.activate "bootstrap-sass" do
   Bootstrap.load!
 end


### PR DESCRIPTION
… shell for redirect.

Add some details on the setup

- [ ] I have added or updated the specs/tests.
- [ ] I have verified that the specs/tests pass on my computer.
- [x] I have not attempted to bump, or alter versions.
- [x] This is a documentation change.
- [x] This is a source change.

## Description

Hi,

Boostrap-sass gem is not where the "real" bootstrap 3.x is, it's a empty shell with a redirect message.

This correctly include and document the use of boo**t**strap-sass gem, and also i tried to add a bit of 'context' to the samples in the documentation.

Regards