### PR TITLE
[3.0] Fix typo in bootstrap-sass gem name

### DIFF
--- a/lib/jekyll/assets/plugins/bootstrap.rb
+++ b/lib/jekyll/assets/plugins/bootstrap.rb
@@ -3,6 +3,6 @@
 # Encoding: utf-8
 
 Jekyll::Assets::Utils.activate "bootstrap"
-Jekyll::Assets::Utils.activate "boostrap-sass" do
+Jekyll::Assets::Utils.activate "bootstrap-sass" do
   Bootstrap.load!
 end


### PR DESCRIPTION
Followup to #555
