### PR TITLE
Fix incorrect asset path generated in dev env

### DIFF
--- a/lib/jekyll/assets/utils.rb
+++ b/lib/jekyll/assets/utils.rb
@@ -253,9 +253,9 @@ module Jekyll
         path << dest if Jekyll.dev? || !cdn || (cdn && cfg[:cdn][:destination])
         path << user_path unless user_path.nil? || user_path == ""
 
-        path = File.join(path.flatten.compact.reject(&:empty?))
+        path = File.join(path.flatten.compact)
         return path if cdn && Jekyll.production?
-        File.join('', path)
+        File.join("", path)
       end
 
       # --

--- a/lib/jekyll/assets/utils.rb
+++ b/lib/jekyll/assets/utils.rb
@@ -253,9 +253,9 @@ module Jekyll
         path << dest if Jekyll.dev? || !cdn || (cdn && cfg[:cdn][:destination])
         path << user_path unless user_path.nil? || user_path == ""
 
-        path = File.join(path.flatten.compact)
+        path = File.join(path.flatten.compact.reject(&:empty?))
         return path if cdn && Jekyll.production?
-        "/" + path
+        File.join('', path)
       end
 
       # --

--- a/spec/tests/lib/jekyll/assets/utils_spec.rb
+++ b/spec/tests/lib/jekyll/assets/utils_spec.rb
@@ -432,6 +432,22 @@ describe Jekyll::Assets::Utils do
           out = subject.prefix_url
           expect(out).to start_with("/hello")
         end
+
+        #
+
+        context "when jekyll.config[:baseurl] is set to '/'" do
+          before do
+            stub_jekyll_config({
+              baseurl: "/",
+            })
+          end
+
+          it "creates valid path" do
+            out = subject.prefix_url
+            destination = subject.asset_config[:destination]
+            expect(out).to eq(destination)
+          end
+        end
       end
 
       #


### PR DESCRIPTION
I receive incorrect asset path in dev environment. Example:
```
//assets/application-c25b45245c40428e91afc890917c686f31ac5d4b03e05df0d1c67c7f492cb35c.js
```
but it should be (no extra slash at start)
```
/assets/application-c25b45245c40428e91afc890917c686f31ac5d4b03e05df0d1c67c7f492cb35c.js
```
This should fix this problem

- [ ] I have added or updated the specs/tests.
- [ ] I have verified that the specs/tests pass on my computer.
- [ ] I have not attempted to bump, or alter versions.
- [ ] This is a documentation change.
- [x] This is a source change.

## Description

<!--
  What issue are you trying to resolve?
  It's always nice to get a brief description.
  Note: you should provide the same in your commit message.
    not everybody uses Github's Web UI.
-->
