### PR TITLE
Replace image_optim_bin gem with image_optim_pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,7 +496,7 @@ to get an idea what `<value>` can be.
 
 ```ruby
 gem "image_optim"
-gem "image_optim_bin" # Optional
+gem "image_optim_pack" # Optional
 ```
 
 #### Configuration
@@ -509,7 +509,7 @@ assets:
         {}
 ```
 
-Check the [ImageOptim](https://github.com/toy/image_optim#configuration) to get idea about configuration options, and to get a list of stuff you need to install on your system to use it, if you do not wish to use "image_optim_bin".
+Check the [ImageOptim](https://github.com/toy/image_optim#configuration) to get idea about configuration options, and to get a list of stuff you need to install on your system to use it, if you do not wish to use "image_optim_pack".
 
 To disable ImageOptim (i.e. for development builds), use following configuration:
 


### PR DESCRIPTION
- [ ] I have added or updated the specs/tests.
- [x] I have verified that the specs/tests pass on my computer.
- [x] I have not attempted to bump, or alter versions.
- [x] This is a documentation change.
- [ ] This is a source change.

## Description

The `image_optim_bin` gem does not seem to be in active development whereas the `image_optim_pack` gem is in active development and also maintained by the same person as the `image_optim gem` so would likely be the better option for compatibility.