### PR TITLE
Fix `boostrap-sass` typo in README instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,8 +447,8 @@ assets:
 ### Bootstrap
 
 ```ruby
-gem "boostrap-sass" # 3.x
-gem "bootstrap"     # 4.x
+gem "bootstrap-sass" # 3.x
+gem "bootstrap"      # 4.x
 ```
 
 ```scss


### PR DESCRIPTION
- [ ] I have added or updated the specs/tests.
- [ ] I have verified that the specs/tests pass on my computer.
- [x] I have not attempted to bump, or alter versions.
- [x] This is a documentation change.
- [ ] This is a source change.

## Description

<!--
  What issue are you trying to resolve?
  It's always nice to get a brief description.
  Note: you should provide the same in your commit message.
    not everybody uses Github's Web UI.
-->
