### PR TITLE
magick:2x is not supported anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,9 @@ plugins:
 ## Tag `{% asset %}`, `<img>`
 
 ```html
-{% asset src @magick:2x alt='This is my alt' %}
-{% asset src @magick:2x alt='This is my alt' %}
-<img src="src" asset="@magick:2x" alt="This is my alt">
+{% asset src @magick:double alt='This is my alt' %}
+{% asset src @magick:double alt='This is my alt' %}
+<img src="src" asset="@magick:double" alt="This is my alt">
 <img src="src" alt="This is my alt" asset>
 ```
 
@@ -312,7 +312,7 @@ Using Liquid Drop `assets`, you can check whether an asset is present.
 ## Filter
 
 ```liquid
-{{ src | asset:"@magick:2x magick:quality=92" }}
+{{ src | asset:"@magick:double magick:quality=92" }}
 ```
 
 ## Polymer WebComponents


### PR DESCRIPTION
- [ ] I have added or updated the specs/tests.
- [x] I have verified that the specs/tests pass on my computer.
- [x] I have not attempted to bump, or alter versions.
- [X] This is a documentation change.
- [ ] This is a source change.

## Description
`magick:2x` is not supported anymore, it was changed to `magick:double` in this commit https://github.com/envygeeks/jekyll-assets/commit/337aa1316199c5ecc3ce39b255db80c02eb855c9
