### PR TITLE
Add support for liquid in SVG

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,11 +234,15 @@ body {
 ### `.liquid.ext`
 ### `.ext.liquid`
 
-```scss
-.bg {
-  background: url(asset_path("{{ site.background_image }}"));
-}
-```
+#### Supported file types:
+
+- .css
+- .sass
+- .scss
+- .js
+- .es6
+- .coffee
+- .svg
 
 You have full access to your entire global context from any liquid
 processing we do.  Depending on where you do it, you might or might not also have access to your local (page) context as well. You can also do whatever you like, and be as dynamic as you like, including full loops, and conditional Liquid, since we pre-process your text files. *On Sprockets 4.x you can use `.liquid.ext` and `.ext.liquid`, but because of the way Sprockets 3.x works, we have opted to only allow the default extension of `.ext.liquid` when running on "Old Sprockets" (AKA 3.x.)  If you would like Syntax + Liquid you should opt to install Sprockets 4.x so you can get the more advanced features.*

--- a/lib/jekyll/assets/plugins/liquid.rb
+++ b/lib/jekyll/assets/plugins/liquid.rb
@@ -14,6 +14,7 @@ module Jekyll
           "text/liquid+coffeescript" => %w(.liquid.coffee .coffee.liquid),
           "text/liquid+scss" => %w(.liquid.scss .scss.liquid),
           "text/liquid+css" => %w(.liquid.css .css.liquid),
+          "image/liquid+svg+xml" => %w(.liquid.svg .svg.liquid),
         }.freeze
 
         def self.call(ctx)

--- a/lib/jekyll/assets/utils.rb
+++ b/lib/jekyll/assets/utils.rb
@@ -254,7 +254,7 @@ module Jekyll
       def strip_secondary_content_type(str)
         str = str.split("/")
         raise ArgumentError, "#{str.join('/')} is invalid." if str.size > 2
-        File.join(str[0], str[1].rpartition(%r!\+!).last)
+        File.join(str[0], str[1].split('+').tap(&:shift).join('+'))
       end
 
       # --

--- a/spec/fixture/_assets/img/plugins/liquid/basic1.liquid.svg
+++ b/spec/fixture/_assets/img/plugins/liquid/basic1.liquid.svg
@@ -1,0 +1,1 @@
+<svg height="{{ 1 | plus:2 }}"></svg>

--- a/spec/fixture/_assets/img/plugins/liquid/basic2.svg.liquid
+++ b/spec/fixture/_assets/img/plugins/liquid/basic2.svg.liquid
@@ -1,0 +1,1 @@
+<svg height="{{ 1 | plus:2 }}"></svg>

--- a/spec/tests/lib/jekyll/assets/plugins/liquid_spec.rb
+++ b/spec/tests/lib/jekyll/assets/plugins/liquid_spec.rb
@@ -4,6 +4,30 @@
 
 require "rspec/helper"
 describe "Plugins/Liquid" do
+  context "w/ .svg.liquid" do
+    let(:asset) do
+      env.find_asset!("plugins/liquid/basic1.svg")
+    end
+
+    #
+
+    it "works" do
+      expect(asset.to_s.strip).to match(%q!<svg height="3"></svg>!)
+    end
+  end
+
+  context "w/ .liquid.svg" do
+    let(:asset) do
+      env.find_asset!("plugins/liquid/basic2.svg")
+    end
+
+    #
+
+    it "works" do
+      expect(asset.to_s.strip).to match(%q!<svg height="3"></svg>!)
+    end
+  end
+
   context "w/ .scss.liquid" do
     let(:asset) do
       env.find_asset!("plugins/liquid/basic1.css")

--- a/spec/tests/lib/jekyll/assets/utils_spec.rb
+++ b/spec/tests/lib/jekyll/assets/utils_spec.rb
@@ -445,4 +445,22 @@ describe Jekyll::Assets::Utils do
       end
     end
   end
+
+  #
+
+  describe "#strip_secondary_content_type" do
+    context "w/ text/liquid+css" do
+      it "works" do
+        out = described_class.strip_secondary_content_type("text/liquid+css")
+        expect(out).to(eq("text/css"))
+      end
+    end
+
+    context "w/ image/liquid+svg+xml" do
+      it "works" do
+        out = described_class.strip_secondary_content_type("image/liquid+svg+xml")
+        expect(out).to(eq("image/svg+xml"))
+      end
+    end
+  end
 end


### PR DESCRIPTION
- [x] I have added or updated the specs/tests.
- [x] I have verified that the specs/tests pass on my computer.
- [x] I have not attempted to bump, or alter versions.
- [ ] This is a documentation change.
- [x] This is a source change.

Currently assets can be processed by Liquid by appending or prepending `.liquid` to the extension, however this only applies to javascript and css (including sass and coffeescript). It would be useful to be able to include SVG files to this list, because SVG is capable of referencing other files - for example using `<image xlink:href="..."></image>`. Using liquid would enable referencing the digest path of a compiled asset using `<image xlink:href="{% asset path/to/asset @path %}"></image>`.

This PR adds a new `image/liquid+svg+xml` entry as well as a change to `Utils#strip_secondary_content_type` in order to support it.