### PR TITLE
Fix YAML syntax error

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ assets:
   compression: false # true on JEKYLL_ENV=production
   gzip: false
   defaults:
-     js: { integrity: false } # true on JEKYLL_ENV=production
+    js: { integrity: false } # true on JEKYLL_ENV=production
     css: { integrity: false } # true on JEKYLL_ENV=production
     img: { integrity: false } # true on JEKYLL_ENV=production
   caching:


### PR DESCRIPTION
This small space solves ``<ParseException> Indentation problem. (line 8: '  css: { integrity: false } # true on JEKYLL_ENV=production')`` error

- [ ] I have added or updated the specs/tests.
- [ ] I have verified that the specs/tests pass on my computer.
- [ ] I have not attempted to bump, or alter versions.
- [x] This is a documentation change.
- [ ] This is a source change.

## Description

<!--
  What issue are you trying to resolve?
  It's always nice to get a brief description.
  Note: you should provide the same in your commit message.
    not everybody uses Github's Web UI.
-->
