### PR TITLE
Add vips plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,114 @@ assets:
 
 ***By default `@optim` will use the default `jekyll`, otherwise you can provide `optim=preset` and have it used that preset.  ImageOptim provides advanced, and default as their default presets, you can define your own preset via Jekyll Assets configuration listed above.***
 
+### libvips
+
+```ruby
+gem "ruby-vips"
+```
+
+The "ruby-vips" gem requires a functional install of (libvips)[https://github.com/libvips/libvips/].
+
+#### Args
+
+| Name                  | Accepts Value |
+| --------------------- | ------------- |
+| `vips:compression`    | ✔             |
+| `vips:resize`         | ✔             |
+| `vips:format`         | ✔             |
+| `vips:quality`        | ✔             |
+| `vips:crop`           | ✔             |
+| `@vips:interlace`     | ✗             |
+| `vips:strip`          | ✔             |
+| `@vips:strip`         | ✗             |
+| `@vips:lossless`      | ✗             |
+| `@vips:near_lossless` | ✗             |
+
+##### vips:compression
+
+Only has any meaning for lossless image formats such as PNG or lossless WEBP.
+
+```liquid
+{% asset image.png vips:compression=9 %}
+```
+
+##### vips:resize
+
+Accepts an argument of either 'width', 'xheight' or 'widthxheight'.
+
+All resize processes keep the original aspect ratio so width and height
+are used to specify the bounding box for the resize process.
+
+If no height is specified the image is resized to fit withing a bounding
+box of 'width' x 'width'. Similarly specifying just a height sets the
+bounding box for the resize to 'height' x 'height'. This form only exists
+for compatibility with the "magick" plugin.
+
+```liquid
+{% asset image.png vips:resize='100' %}
+```
+
+```liquid
+{% asset image.png vips:resize='100x50' %}
+```
+
+##### vips:format
+
+Convert the image to the specified format. Format support depends on the
+compile options of the libvips library.
+
+Format is specified as the file extension such as '.jpg', '.webp' or '.png'.
+
+```liquid
+{% asset image.png vips:format='.webp' %}
+```
+
+##### vips:quality
+
+Only has any meaning for lossy image formats such as JPEG or WEBP.
+
+```liquid
+{% asset image.jpg vips:quality=90 %}
+```
+
+##### vips:crop
+
+Only has any effect when combined with "vips:resize".
+
+Use the following arguments (all except "fill" are documented [here](http://libvips.github.io/libvips/API/current/libvips-conversion.html#VipsInteresting)):
+
+* fill: resize the image to the specified size while maintaining the aspect ratio
+  then fills the "empty" background with blurred version of the original image
+* none: do nothing
+* centre: crop from the centre
+* entropy: use an entropy measure
+* attention: look for features likely to draw human attention
+* low: position the crop towards the low coordinate
+* high: position the crop towards the high coordinate
+
+```liquid
+{% asset image.jpg vips:resize='100' vips:crop='fill' %}
+```
+
+##### vips:strip
+
+Removes metadata from images.
+
+This is set "true" by default, but can be disabled by passing "false".
+
+```liquid
+{% asset image.jpg vips:strip=false %}
+```
+
+##### vips:lossless and vips:near_lossless
+
+These options only have any effect when the format is WEBP. This sets either
+lossless or near lossless mode.
+
+```liquid
+{% asset image.jpg vips:format='.webp' @vips:lossless %}
+```
+
 ### Building Your Own Plugins
 #### Globals
 

--- a/README.md
+++ b/README.md
@@ -558,6 +558,8 @@ The "ruby-vips" gem requires a functional install of (libvips)[https://github.co
 | `@vips:strip`         | ✗             |
 | `@vips:lossless`      | ✗             |
 | `@vips:near_lossless` | ✗             |
+| `@vips:double`        | ✗             |
+| `@vips:half`          | ✗             |
 
 ##### vips:compression
 

--- a/jekyll-assets.gemspec
+++ b/jekyll-assets.gemspec
@@ -52,4 +52,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency("rubocop", "0.52")
   s.add_development_dependency("rake", "~> 12")
   s.add_development_dependency("pry", "~> 0")
+  s.add_development_dependency("ruby-vips", "~> 2")
 end

--- a/lib/jekyll/assets/plugins/proxy/vips.rb
+++ b/lib/jekyll/assets/plugins/proxy/vips.rb
@@ -67,6 +67,14 @@ module Jekyll
             img = vips_resize(img)
           end
 
+          if @args[:vips].key?(:double)
+            img = vips_double(img)
+          end
+
+          if @args[:vips].key?(:half)
+            img = half(img)
+          end
+
           out_file = in_file.sub_ext(out_ext)
           buf = img.write_to_buffer out_ext, write_opts
           
@@ -180,6 +188,23 @@ module Jekyll
 
           newimg
         end
+
+        # vips:double
+        # doubles the size of the image
+        private
+        def vips_double(img)
+          newimg = img.resize(2)
+          newimg
+        end
+
+        # vips:half
+        # halves the size of the image
+        private
+        def vips_half(img)
+          newimg = img.resize(0.5)
+          newimg
+        end
+
       end
     end
   end

--- a/lib/jekyll/assets/plugins/proxy/vips.rb
+++ b/lib/jekyll/assets/plugins/proxy/vips.rb
@@ -65,14 +65,10 @@ module Jekyll
 
           if @args[:vips].key?(:resize)
             img = vips_resize(img)
-          end
-
-          if @args[:vips].key?(:double)
+          elsif @args[:vips].key?(:double)
             img = vips_double(img)
-          end
-
-          if @args[:vips].key?(:half)
-            img = half(img)
+          elsif @args[:vips].key?(:half)
+            img = vips_half(img)
           end
 
           out_file = in_file.sub_ext(out_ext)

--- a/lib/jekyll/assets/plugins/proxy/vips.rb
+++ b/lib/jekyll/assets/plugins/proxy/vips.rb
@@ -1,0 +1,186 @@
+# Frozen-string-literal: true
+# Copyright: 2019 - MIT License
+# Author: Andrew Heberle
+# Encoding: utf-8
+
+module Jekyll
+  module Assets
+    module Plugins
+      class Vips < Proxy
+        content_types %r!^image/(?\!x-icon$)[a-zA-Z0-9\-_\+]+$!
+        arg_keys :vips
+
+        # handles the vips process
+        # by default images are stripped
+        # some defaults for certain image formats are set as follows:
+        #  JPEG = interlace (true), optimized encoding (true)
+        #  WEBP = lossless (via "vips:lossless"), near_lossless (via
+        #    "vips:near_lossless")
+        #  PNG  = compression (via "vips:compression=X"), interlace (via
+        #    "vips:interlace"
+        #
+        # libvips builds a "pipeline" of processes which are executed on write
+        #
+        # write_opts is added to and then used via "img.write_to_buffer"
+
+        def process
+          in_file = @file
+          in_ext = in_file.extname
+
+          img = ::Vips::Image.new_from_file in_file
+
+          if @args[:vips].key?(:format)
+            format = ".#{@args[:vips][:format].sub(%r!^\.!, '')}"
+            ext = @env.mime_exts.find { |k, v| k == format || v == format }
+            out_ext, type = ext
+          else
+            out_ext = in_ext
+          end
+
+          write_opts = {}
+
+          case out_ext
+          when ".jpg", ".jpeg"
+            write_opts[:interlace] = true
+            write_opts[:optimize_coding] = true
+          when ".webp"
+            write_opts[:lossless] = @args[:vips].key?(:lossless)
+            write_opts[:near_lossless] = @args[:vips].key?(:near_lossless)
+          when ".png"
+            if @args[:vips].key?(:compression)
+              write_opts[:compression] = @args[:vips][:compression]
+            end
+            write_opts[:interlace] = @args[:vips].key?(:interlace)
+          end
+
+          if @args[:vips].key?(:quality)
+            write_opts = vips_quality(write_opts)
+          end
+
+          if @args[:vips].key?(:strip)
+            write_opts[:strip] = vips_strip(write_opts)
+          else
+            write_opts[:strip] = true
+          end
+
+          if @args[:vips].key?(:resize)
+            img = vips_resize(img)
+          end
+
+          out_file = in_file.sub_ext(out_ext)
+          buf = img.write_to_buffer out_ext, write_opts
+          
+          @file.binwrite(buf)
+
+          if @file != out_file
+            @file.rename(out_file)
+          end
+
+          out_file
+        end
+
+        # vips:compression=<compression>
+        # sets the compression for the operation
+        # only makes sense for losseless image formats
+        private
+        def vips_compression(opts)
+          opts[:compression] = @args[:vips][:compression].to_i
+          opts
+        end
+
+        # vips:quality=<quality>
+        # sets the quality for the operation
+        # only makes sense for lossy image formats
+        private
+        def vips_quality(opts)
+          opts[:Q] = @args[:vips][:quality].to_i
+          opts
+        end
+
+        # vips:strip
+        # strips metadata from an image
+        private
+        def vips_strip(opts)
+          opts[:strip] = @args[:vips][:strip]
+          opts
+        end
+
+        # vips:resize='<width>[x<height>]'
+        # resizes an image via vips
+        # will resize to  sepcified width, height or both
+        # can also crop to that size or fill "extra" space
+        # extra space is filled with blurred version of image
+        # that is expanded to fill space
+        private
+        def vips_resize(img)
+          resize_opts = {}
+          if @args[:vips][:resize].is_a? Integer
+            width = @args[:vips][:resize]
+          else
+            if @args[:vips][:resize].include? "x"
+              width, height = @args[:vips][:resize].split("x")
+              if width == "" or width == nil
+                width = 0
+              else
+                width = width.to_i
+              end
+              if height == "" or height == nil
+                height = width
+              else
+                height = height.to_i
+                resize_opts[:height] = height
+                if width == 0
+                  width = height.to_i
+                end
+              end
+            else
+              width = @args[:vips][:resize].to_i
+            end
+            if @args[:vips].key?(:crop)
+              if @args[:vips][:crop] == "fill"
+                do_fill = true
+              else
+                do_fill = false
+                resize_opts[:crop] = @args[:vips][:crop]
+              end
+            end
+          end
+
+          newimg = img.thumbnail_image width, resize_opts
+
+          if do_fill
+            actual_width = newimg.width
+            actual_height = newimg.height
+            if actual_width != width || actual_height != height
+              if actual_width > actual_height
+                ratio = actual_width.to_f / actual_height.to_f
+                crop_y = 0
+              elsif actual_height > actual_width
+                crop_x = 0
+                ratio = actual_height.to_f / actual_width.to_f
+              else
+                ratio = 1
+              end
+              blur_w = (ratio * actual_width).round
+              blur_h = (ratio * actual_height).round
+              crop_x = (blur_w - width) / 2
+              crop_y = (blur_h - height) / 2
+              blur = img.thumbnail_image blur_w, height: blur_h
+              blur = blur.gaussblur 10
+              x_origin = ((blur.width - actual_width) / 2).floor
+              y_origin = ((blur.height - actual_height) / 2).floor
+              newimg = blur.draw_image newimg, x_origin, y_origin
+              if crop_x + width > blur.width || crop_y + height > blur.height
+                width = width - 1
+                height = height - 1
+              end
+              newimg = newimg.extract_area crop_x, crop_y, width, height
+            end
+          end
+
+          newimg
+        end
+      end
+    end
+  end
+end

--- a/lib/jekyll/assets/plugins/vips.rb
+++ b/lib/jekyll/assets/plugins/vips.rb
@@ -1,0 +1,8 @@
+# Frozen-string-literal: true
+# Copyright: 2019 - MIT License
+# Author: Andrew Heberle
+# Encoding: utf-8
+
+Jekyll::Assets::Utils.activate("ruby-vips") do
+    require_relative "proxy/vips"
+  end

--- a/spec/fixture/plugins/vips/compress.html
+++ b/spec/fixture/plugins/vips/compress.html
@@ -1,0 +1,4 @@
+---
+---
+
+{% asset img.png vips:compression=9 %}

--- a/spec/fixture/plugins/vips/double.html
+++ b/spec/fixture/plugins/vips/double.html
@@ -1,0 +1,4 @@
+---
+---
+
+{% asset img.png @vips:double %}

--- a/spec/fixture/plugins/vips/format.html
+++ b/spec/fixture/plugins/vips/format.html
@@ -1,0 +1,4 @@
+---
+---
+
+{% asset img.png vips:format='.jpg' %}

--- a/spec/fixture/plugins/vips/half.html
+++ b/spec/fixture/plugins/vips/half.html
@@ -1,0 +1,4 @@
+---
+---
+
+{% asset img.png @vips:half %}

--- a/spec/fixture/plugins/vips/resize.html
+++ b/spec/fixture/plugins/vips/resize.html
@@ -1,0 +1,4 @@
+---
+---
+
+{% asset img.png vips:resize='100x100' vips:crop='fill' %}

--- a/spec/tests/lib/jekyll/assets/plugins/vips_spec.rb
+++ b/spec/tests/lib/jekyll/assets/plugins/vips_spec.rb
@@ -51,4 +51,36 @@ describe "Plugins/Vips" do
       expect(h).to(eq(100))
     end
   end
+
+  describe "double" do
+    let :page do
+      jekyll.pages.find do |v|
+        v.path == "plugins/vips/double.html"
+      end
+    end
+
+    it "should be doubled" do
+      frag = fragment(page.to_s).children.first
+      w1, h1 = FastImage.size(asset.filename)
+      w2, h2 = FastImage.size(env.jekyll.in_dest_dir(frag.attr("src")))
+      expect(w2).to(eq(w1 * 2))
+      expect(h2).to(eq(h1 * 2))
+    end
+  end
+
+  describe "half" do
+    let :page do
+      jekyll.pages.find do |v|
+        v.path == "plugins/vips/half.html"
+      end
+    end
+
+    it "should be halved" do
+      frag = fragment(page.to_s).children.first
+      w1, h1 = FastImage.size(asset.filename)
+      w2, h2 = FastImage.size(env.jekyll.in_dest_dir(frag.attr("src")))
+      expect(w2).to(eq(w1 * 0.5))
+      expect(h2).to(eq(h1 * 0.5))
+    end
+  end
 end

--- a/spec/tests/lib/jekyll/assets/plugins/vips_spec.rb
+++ b/spec/tests/lib/jekyll/assets/plugins/vips_spec.rb
@@ -1,0 +1,54 @@
+# Frozen-string-literal: true
+# Copyright: 2019 - MIT License
+# Encoding: utf-8
+
+require "rspec/helper"
+describe "Plugins/Vips" do
+  let :asset do
+    env.find_asset!("img.png")
+  end
+
+  describe "format" do
+    let :page do
+      jekyll.pages.find do |v|
+        v.path == "plugins/vips/format.html"
+      end
+    end
+
+    it "should be jpeg" do
+      frag = fragment(page.to_s).children.first
+      t = FastImage.type(env.jekyll.in_dest_dir(frag.attr("src")))
+      expect(t).to(eq(:jpeg))
+    end
+  end
+
+  describe "compress" do
+    let :page do
+      jekyll.pages.find do |v|
+        v.path == "plugins/vips/compress.html"
+      end
+    end
+
+    it "should be smaller" do
+      frag = fragment(page.to_s).children.first
+      file = Pathutil.new(env.jekyll.in_dest_dir(frag.attr(:src)))
+      asst = Pathutil.new(asset.filename)
+      expect(file.size).to be < asst.size
+    end
+  end
+
+  describe "resize" do
+    let :page do
+      jekyll.pages.find do |v|
+        v.path == "plugins/vips/resize.html"
+      end
+    end
+
+    it "should be 100x100" do
+      frag = fragment(page.to_s).children.first
+      w, h = FastImage.size(env.jekyll.in_dest_dir(frag.attr("src")))
+      expect(w).to(eq(100))
+      expect(h).to(eq(100))
+    end
+  end
+end


### PR DESCRIPTION
- [x] I have added or updated the specs/tests.
- [x] I have verified that the specs/tests pass on my computer.
- [x] I have not attempted to bump, or alter versions.
- [ ] This is a documentation change.
- [x] This is a source change.

## Description

This adds a "vips" plugin to process images using ruby-vips, which uses the libvips image library (https://github.com/libvips/libvips). This can be considered an alternative for the "magick" plugin for basic conversion "vips:format" and scaling "vips:resize" operations. These image operations should be significantly faster that the equivalent "magick" operation.

 - vips:resize (<width>, x<height> or <width>x<height>)
 - vips:quality
 - vips:format
 - vips:crop (accepts "fill", or options as per https://www.rubydoc.info/gems/ruby-vips/Vips/Interesting)
 - vips:compression (only for lossless image formats)
 - vips:strip (true/false) - defaults to true
 - vips:interlace
 - vips:lossless (only for webp - ie vips:format='.webp')
 - vips:near_lossless (only for webp - ie vips:format='.webp')

Where possible the usage mirrors the "magick" plugin, which
may not match the underlying ruby-vips/libvips API docs:

https://www.rubydoc.info/gems/ruby-vips

### Anecdote

For my Jekyll use case, a build of my site via GitLab CI would take approximately 90 minutes (I have a lot of images, plus a lot of resizing for different DPI devices), which now takes approximately 15 minutes after replacing all "magick:format" and "magick:resize" occurrences with "vips:format" and "vips:resize".

I can't take any real credit for this performance really however as it's purely due to the underlying image library (libvips).
