### PR TITLE
use 'baseurl_root' if posible for assets path

### DIFF
--- a/lib/jekyll/assets/utils.rb
+++ b/lib/jekyll/assets/utils.rb
@@ -228,7 +228,8 @@ module Jekyll
       def prefix_url(user_path = nil)
         dest = strip_slashes(asset_config[:destination])
         cdn = make_https(strip_slashes(asset_config[:cdn][:url]))
-        base = strip_slashes(jekyll.config["baseurl"])
+        base_org = jekyll.config["baseurl_root"] || jekyll.config["baseurl"]
+        base = strip_slashes(base_org)
         cfg = asset_config
 
         path = []

--- a/lib/jekyll/assets/utils.rb
+++ b/lib/jekyll/assets/utils.rb
@@ -228,6 +228,8 @@ module Jekyll
       def prefix_url(user_path = nil)
         dest = strip_slashes(asset_config[:destination])
         cdn = make_https(strip_slashes(asset_config[:cdn][:url]))
+        # Any Jekyll plugin overwriting 'baseurl' such as jekyll-multiple-languages-plugin
+        # should first alias the original value to 'baseurl_root'
         base_org = jekyll.config["baseurl_root"] || jekyll.config["baseurl"]
         base = strip_slashes(base_org)
         cfg = asset_config


### PR DESCRIPTION
- [ ] I have added or updated the specs/tests.
- [X] I have verified that the specs/tests pass on my computer.
- [x] I have not attempted to bump, or alter versions.
- [ ] This is a documentation change.
- [X] This is a source change.

## Description

What issue are you trying to resolve?
use 'baseurl_root' if posible for assets path.
This fixes the issue with the plugin "jekyll-multiple-languages-plugin" opened here: https://github.com/envygeeks/jekyll-assets/issues/507
