### PR TITLE
Fixing clash with multilingual plugin. Use 'baseurl_root' if posible for assets path.

### DIFF
--- a/lib/jekyll/assets/utils.rb
+++ b/lib/jekyll/assets/utils.rb
@@ -245,7 +245,9 @@ module Jekyll
       def prefix_url(user_path = nil)
         dest = strip_slashes(asset_config[:destination])
         cdn = make_https(strip_slashes(asset_config[:cdn][:url]))
-        base_org = jekyll.config['baseurl_root'] || jekyll.config["baseurl"]
+        # Any Jekyll plugin overwriting 'baseurl' such as jekyll-multiple-languages-plugin
+        # should first alias the original value to 'baseurl_root'
+        base_org = jekyll.config["baseurl_root"] || jekyll.config["baseurl"]
         base = strip_slashes(base_org)
         cfg = asset_config
 

--- a/lib/jekyll/assets/utils.rb
+++ b/lib/jekyll/assets/utils.rb
@@ -245,7 +245,8 @@ module Jekyll
       def prefix_url(user_path = nil)
         dest = strip_slashes(asset_config[:destination])
         cdn = make_https(strip_slashes(asset_config[:cdn][:url]))
-        base = strip_slashes(jekyll.config["baseurl"])
+        base_org = jekyll.config['baseurl_root'] || jekyll.config["baseurl"]
+        base = strip_slashes(base_org)
         cfg = asset_config
 
         path = []


### PR DESCRIPTION
- [ ] I have added or updated the specs/tests.
- [x] I have verified that the specs/tests pass on my computer.
- [x] I have not attempted to bump, or alter versions.
- [ ] This is a documentation change.
- [x] This is a source change.

## Description

  What issue are you trying to resolve?
  use 'baseurl_root' if posible for assets path.
This fixes the issue with the plugin "jekyll-multiple-languages-plugin" opened here: https://github.com/envygeeks/jekyll-assets/issues/507

This pull request has also been submitted into to the master branch https://github.com/envygeeks/jekyll-assets/pull/602
