### PR TITLE
Fix integrity config example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,12 @@ assets:
   compression: false
   gzip: false
   defaults:
-    integrity:
-      {css,img,js}: false
+    img:
+      integrity: true
+    css:
+      integrity: true
+    js:
+      integrity: true
   caching:
     enabled: true
     path: ".jekyll-cache/assets"


### PR DESCRIPTION
- [ ] I have added or updated the specs/tests.
- [ ] I have verified that the specs/tests pass on my computer.
- [x] I have not attempted to bump, or alter versions.
- [x] This is a documentation change.
- [ ] This is a source change.

## Description

I was looking for a way to prevent `<img>` elements from having an `integrity` attribute because that's not valid HTML. I saw this config snippet in the README:

```yaml
assets:
  defaults:
    integrity:
      {css,img,js}: false
```

I tried it out, but I got an exception (`undefined method 'key?' for "highlighter":String`). After reading the source code I found this hint:
https://github.com/envygeeks/jekyll-assets/blob/056d2c88719ef3b1f90967a606dd1441581dd832/lib/jekyll/assets/plugins/html/defaults/img.rb#L59-L68

It drove me to realize that this config will do what I want:

```yaml
assets:
  defaults:
    img:
      integrity: false
```

Additionally, the README says that "All values listed below are default", which made me unsure if the values should be set to `true` or `false` because the real default value is `Jekyll.production?`. I chose `true` because I consider it's more important to know what happens in production, but let me know if you disagree. Maybe a comment would be necessary?