### PR TITLE
Fix wrong number of arguments in proxy.rb and writer.rb

### DIFF
--- a/lib/jekyll/assets/patches/writer.rb
+++ b/lib/jekyll/assets/patches/writer.rb
@@ -25,9 +25,9 @@ module Jekyll
         # --
         def call
           before_hook(asset, env: environment)
-          after_hook(out = super, {
+          after_hook(out = super,
             env: environment, asset: asset
-          })
+          )
 
           out
         end

--- a/lib/jekyll/assets/proxy.rb
+++ b/lib/jekyll/assets/proxy.rb
@@ -32,11 +32,11 @@ module Jekyll
         out = env.cache.fetch(key) do
           file = copy(asset, args: args, ctx: ctx)
           proxies.each do |o|
-            obj = o.new(file, {
+            obj = o.new(file,
               args: args,
               asset: asset,
               ctx: ctx
-            })
+            )
 
             o = obj.process
             file = o if o.is_a?(Pathutil) && file != o
@@ -52,10 +52,10 @@ module Jekyll
       # --
       def self.proxies_for(asset:, args:)
         Proxy.inherited.select do |o|
-          o.for?({
+          o.for?(
             type: asset.content_type,
             args: args,
-          })
+          )
         end
       end
 


### PR DESCRIPTION
- [ ] I have added or updated the specs/tests.
- [ ] I have verified that the specs/tests pass on my computer.
- [ ] I have not attempted to bump, or alter versions.
- [ ] This is a documentation change.
- [ x] This is a source change.

## Description

<!--
  Ruby 3 causes issues with the number of arguments in some function calls in proxy.rb and writer.rb with error messages like this: "wrong number of arguments (given 2, expected 1) (ArgumentError)". These changes were successfully tested with Ruby 3.1.2, Ruby 2.7, and Jekyll 3.9.2. 
-->
